### PR TITLE
Fixed contact list skipping issue

### DIFF
--- a/VelcroPhysics/Collision/ContactSystem/ContactManager.cs
+++ b/VelcroPhysics/Collision/ContactSystem/ContactManager.cs
@@ -242,9 +242,8 @@ namespace VelcroPhysics.Collision.ContactSystem
         internal void Collide()
         {
             // Update awake contacts.
-            for (int i = 0; i < ContactList.Count; i++)
+            foreach (Contact c in ContactList.ToArray())
             {
-                Contact c = ContactList[i];
                 Fixture fixtureA = c.FixtureA;
                 Fixture fixtureB = c.FixtureB;
                 int indexA = c.ChildIndexA;


### PR DESCRIPTION
ContactManager.Collide would skip contacts while iterating if Destroy was called. When destroy was called the list was downsized, but i was still incremented. I fixed this by copying the list at the beginning of the iteration.